### PR TITLE
Deployed Publisher- and Subscription-convenience functions with qos best effort in ping_pong

### DIFF
--- a/rclc/ping_pong/main.c
+++ b/rclc/ping_pong/main.c
@@ -89,6 +89,7 @@ void main()
 	RCCHECK(rclc_publisher_init_default(&ping_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/ping"));
 
 	// Create a best effort pong publisher
+	// TODO (pablogs9): RCLC best effort not implemented
 	RCCHECK(rclc_publisher_init_best_effort(&pong_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
 
 	// Create a best effort ping subscriber

--- a/rclc/ping_pong/main.c
+++ b/rclc/ping_pong/main.c
@@ -90,7 +90,7 @@ void main()
 
 	// Create a best effort pong publisher
 	// TODO (pablogs9): RCLC best effort not implemented
-	RCCHECK(rclc_publisher_init_best_effort(&pong_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
+	RCCHECK(rclc_publisher_init_default(&pong_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
 
 	// Create a best effort ping subscriber
 	RCCHECK(rclc_subscription_init_best_effort(&ping_subscriber, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/ping"));

--- a/rclc/ping_pong/main.c
+++ b/rclc/ping_pong/main.c
@@ -89,16 +89,13 @@ void main()
 	RCCHECK(rclc_publisher_init_default(&ping_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/ping"));
 
 	// Create a best effort pong publisher
-	// TODO (pablogs9): RCLC best effort not implemented
-	RCCHECK(rclc_publisher_init_default(&pong_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
+	RCCHECK(rclc_publisher_init_best_effort(&pong_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
 
 	// Create a best effort ping subscriber
-	// TODO (pablogs9): RCLC best effort not implemented
-	RCCHECK(rclc_subscription_init_default(&ping_subscriber, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/ping"));
+	RCCHECK(rclc_subscription_init_best_effort(&ping_subscriber, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/ping"));
 
 	// Create a best effort  pong subscriber
-	// TODO (pablogs9): RCLC best effort not implemented
-	RCCHECK(rclc_subscription_init_default(&pong_subscriber, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
+	RCCHECK(rclc_subscription_init_best_effort(&pong_subscriber, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
 
 
 	// Create a 3 seconds ping timer timer,

--- a/rclc/ping_pong/main.c
+++ b/rclc/ping_pong/main.c
@@ -89,8 +89,7 @@ void main()
 	RCCHECK(rclc_publisher_init_default(&ping_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/ping"));
 
 	// Create a best effort pong publisher
-	// TODO (pablogs9): RCLC best effort not implemented
-	RCCHECK(rclc_publisher_init_default(&pong_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
+	RCCHECK(rclc_publisher_init_best_effort(&pong_publisher, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
 
 	// Create a best effort ping subscriber
 	RCCHECK(rclc_subscription_init_best_effort(&ping_subscriber, &node, ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/ping"));


### PR DESCRIPTION
precondition: 
PR https://github.com/micro-ROS/rclc/pull/34
PR https://github.com/micro-ROS/rclc/pull/35

use of rclc_subscription_init_best_effort in ping_pong example.

@pablogs9  Please first test the change on your platform before accepting the PR. 
I could not test the ping-pong example on my laptop, because I currently don't have a micro-xrcedds setup available.