### PR TITLE
demo: fix stack corruption in ping_pong demo

### DIFF
--- a/rclc/ping_pong/main.c
+++ b/rclc/ping_pong/main.c
@@ -5,6 +5,9 @@
 
 #include <std_msgs/msg/header.h>
 
+#include <rcutils/allocator.h>
+#include <rosidl_runtime_c/string_functions.h>
+
 #include <stdio.h>
 #include <unistd.h>
 #include <time.h>
@@ -110,24 +113,27 @@ int main()
 	RCCHECK(rclc_executor_add_subscription(&executor, &ping_subscriber, &incoming_ping, &ping_subscription_callback, ON_NEW_DATA));
 	RCCHECK(rclc_executor_add_subscription(&executor, &pong_subscriber, &incoming_pong, &pong_subscription_callback, ON_NEW_DATA));
 
-	// Create and allocate the pingpong messages
-
-	char outcoming_ping_buffer[STRING_BUFFER_LEN];
-	outcoming_ping.frame_id.data = outcoming_ping_buffer;
+	// Allocate frame_id buffers via the rcutils allocator before spinning.
+	// The deserializer calls realloc() on frame_id.data when a message arrives;
+	// Remember to pair these with a call to rosidl_runtime_c__String__fini.
+	// outcoming_ping must be preallocated for sprintf to work. The others
+	// are used on paths that automatically realloc().
+	rcutils_allocator_t alloc = rcutils_get_default_allocator();
+	outcoming_ping.frame_id.data = alloc.allocate(STRING_BUFFER_LEN, alloc.state);
 	outcoming_ping.frame_id.capacity = STRING_BUFFER_LEN;
+	outcoming_ping.frame_id.size = 0;
 
-	char incoming_ping_buffer[STRING_BUFFER_LEN];
-	incoming_ping.frame_id.data = incoming_ping_buffer;
-	incoming_ping.frame_id.capacity = STRING_BUFFER_LEN;
-
-	char incoming_pong_buffer[STRING_BUFFER_LEN];
-	incoming_pong.frame_id.data = incoming_pong_buffer;
-	incoming_pong.frame_id.capacity = STRING_BUFFER_LEN;
+	(void) rosidl_runtime_c__String__init(&incoming_ping.frame_id);
+	(void) rosidl_runtime_c__String__init(&incoming_pong.frame_id);
 
 	device_id = rand();
 
 	rclc_executor_spin(&executor);
-	
+
+	rosidl_runtime_c__String__fini(&outcoming_ping.frame_id);
+	rosidl_runtime_c__String__fini(&incoming_ping.frame_id);
+	rosidl_runtime_c__String__fini(&incoming_pong.frame_id);
+
 	RCCHECK(rcl_publisher_fini(&ping_publisher, &node));
 	RCCHECK(rcl_publisher_fini(&pong_publisher, &node));
 	RCCHECK(rcl_subscription_fini(&ping_subscriber, &node));


### PR DESCRIPTION
While running the ping_pong demo I noticed a crash:

ping_pong_1-1  | [ros2run]: Aborted
ping_pong_1-1  | [INFO] [1775242528.757714440] []: Created a timer with period 2000 ms. ping_pong_1-1  |
ping_pong_2-1  | realloc(): invalid old size
ping_pong_1-1  | mremap_chunk(): invalid pointer
ping_pong_2-1  | [ros2run]: Aborted
ping_pong_1-1  | [ros2run]: Aborted

This is caused by stack memory being passed to realloc() at https://github.com/ros2/rosidl/blob/8cdfe315157f8bffa9b73b6750c52f44325a7847/rosidl_runtime_c/src/string_functions.c#L110

Use ros string allocators to handle this safely. The outcoming_ping is sprintf'd so we must preallocate.

After patching my tree I see the expected output

```
subscriber-1  | Pong for seq 1308616470_783094776 (1)
publisher-1   | Ping received with seq 1308616470_783094776. Answering.
publisher-1   | Ping send seq 1267638503_591265725
subscriber-1  | Ping received with seq 1267638503_591265725. Answering.
publisher-1   | Pong for seq 1267638503_591265725 (1)
subscriber-1  | Ping send seq 1379001663_783094776
publisher-1   | Ping received with seq 1379001663_783094776. Answering.
```

Fixes #95 

Signed-off-by: Cory Todd <cory@219design.com>